### PR TITLE
Issue #2: initialise Obsidian docs vault with structure and placeholders

### DIFF
--- a/docs/.obsidian/app.json
+++ b/docs/.obsidian/app.json
@@ -1,0 +1,8 @@
+{
+  "theme": "obsidian",
+  "defaultViewMode": "preview",
+  "livePreview": true,
+  "legacyEditor": false,
+  "foldIndent": true,
+  "showFrontmatter": false
+}

--- a/docs/.obsidian/core-plugins.json
+++ b/docs/.obsidian/core-plugins.json
@@ -1,0 +1,18 @@
+{
+  "file-explorer": true,
+  "global-search": true,
+  "switcher": true,
+  "graph": true,
+  "backlink": true,
+  "outgoing-link": true,
+  "tag-pane": true,
+  "page-preview": true,
+  "starred": true,
+  "markdown-importer": false,
+  "zk-prefixer": false,
+  "random-note": false,
+  "outline": true,
+  "word-count": true,
+  "open-with-default-app": false,
+  "file-recovery": true
+}

--- a/docs/api-reference/_index.md
+++ b/docs/api-reference/_index.md
@@ -1,0 +1,5 @@
+# API Reference
+
+Complete reference for the GraphQL and REST APIs.
+
+> 🚧 Filled in during Phase 2 (Ingest) and Phase 4 (GraphQL).

--- a/docs/api-reference/graphql-schema.md
+++ b/docs/api-reference/graphql-schema.md
@@ -1,0 +1,5 @@
+# GraphQL Schema Reference
+
+Full annotated GraphQL schema with example queries.
+
+> 🚧 Added in Phase 4 (GraphQL API ticket).

--- a/docs/api-reference/ingest-rest-api.md
+++ b/docs/api-reference/ingest-rest-api.md
@@ -1,0 +1,5 @@
+# Ingest REST API Reference
+
+Endpoint reference with curl examples for all ingest operations.
+
+> 🚧 Added in Phase 2 (Ingest API ticket).

--- a/docs/architecture/_index.md
+++ b/docs/architecture/_index.md
@@ -1,0 +1,5 @@
+# Architecture
+
+Architecture diagrams and design decisions for nebullama-search.
+
+> 🚧 Diagrams are added as each component is implemented.

--- a/docs/architecture/aws-architecture.md
+++ b/docs/architecture/aws-architecture.md
@@ -1,0 +1,5 @@
+# AWS Architecture
+
+Mermaid diagram of the AWS deployment topology.
+
+> 🚧 Added in Phase 5 (AWS docs ticket).

--- a/docs/architecture/ingest-pipeline.md
+++ b/docs/architecture/ingest-pipeline.md
@@ -1,0 +1,5 @@
+# Ingest Pipeline
+
+Sequence diagram showing the ingest request lifecycle.
+
+> 🚧 Added in Phase 2 (Ingest API ticket).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,5 @@
+# Architecture Overview
+
+C4-style diagram of the full local nebullama-search stack.
+
+> 🚧 Added in Phase 4 (GraphQL API ticket).

--- a/docs/architecture/search-pipeline.md
+++ b/docs/architecture/search-pipeline.md
@@ -1,0 +1,5 @@
+# Search Pipeline
+
+Sequence diagram showing the full search request lifecycle.
+
+> 🚧 Added in Phase 4 (GraphQL API ticket).

--- a/docs/concepts/_index.md
+++ b/docs/concepts/_index.md
@@ -1,0 +1,5 @@
+# Concepts
+
+Deep-dives into the core technical concepts behind nebullama-search.
+
+> 🚧 Filled in during Phase 3 (Search) and Phase 4 (Intelligence).

--- a/docs/concepts/hybrid-search.md
+++ b/docs/concepts/hybrid-search.md
@@ -1,0 +1,5 @@
+# Hybrid Search
+
+How BM25 and k-NN vector search are combined in nebullama-search.
+
+> 🚧 Added in Phase 3 (Hybrid Search ticket).

--- a/docs/concepts/intent-extraction.md
+++ b/docs/concepts/intent-extraction.md
@@ -1,0 +1,5 @@
+# Intent Extraction
+
+How the LLM parses natural language queries into structured filters.
+
+> 🚧 Added in Phase 4 (Intent Extraction ticket).

--- a/docs/concepts/vector-embeddings.md
+++ b/docs/concepts/vector-embeddings.md
@@ -1,0 +1,5 @@
+# Vector Embeddings
+
+What embeddings are and how nomic-embed-text is used.
+
+> 🚧 Added in Phase 4 (Intent Extraction ticket).

--- a/docs/deployment/_index.md
+++ b/docs/deployment/_index.md
@@ -1,0 +1,5 @@
+# Deployment
+
+Deployment guides for nebullama-search.
+
+> 🚧 AWS deployment guide added in Phase 5.

--- a/docs/deployment/aws.md
+++ b/docs/deployment/aws.md
@@ -1,0 +1,5 @@
+# AWS Deployment
+
+How to deploy nebullama-search to AWS using Bedrock, OpenSearch Serverless, and ECS Fargate.
+
+> 🚧 Added in Phase 5 (AWS docs ticket).

--- a/docs/guides/_index.md
+++ b/docs/guides/_index.md
@@ -1,0 +1,3 @@
+# Guides
+
+Step-by-step operational guides for running and using nebullama-search.

--- a/docs/guides/data-ingestion.md
+++ b/docs/guides/data-ingestion.md
@@ -1,0 +1,5 @@
+# Data Ingestion
+
+How to fetch seed data and bulk-ingest it into nebullama-search.
+
+> 🚧 Added in Phase 2 (Seed Data + Ingest API tickets).

--- a/docs/guides/local-dev-setup.md
+++ b/docs/guides/local-dev-setup.md
@@ -1,0 +1,5 @@
+# Local Dev Setup
+
+How to run the full nebullama-search stack locally.
+
+> 🚧 Added in Phase 1 (Infrastructure ticket).

--- a/docs/guides/running-searches.md
+++ b/docs/guides/running-searches.md
@@ -1,0 +1,5 @@
+# Running Searches
+
+How to query nebullama-search via GraphiQL and curl.
+
+> 🚧 Added in Phase 4 (GraphQL API ticket).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+# nebullama-search
+
+![nebullama icon](assets/nebullama-icon.svg)
+
+A local-dev hybrid search service over astronomy data — a learning project for vector search, OpenSearch k-NN, and LLM-powered intent extraction.
+
+---
+
+## Sections
+
+- [[architecture/overview|Architecture Overview]]
+- [[concepts/hybrid-search|Hybrid Search]]
+- [[concepts/vector-embeddings|Vector Embeddings]]
+- [[concepts/intent-extraction|Intent Extraction]]
+- [[guides/local-dev-setup|Local Dev Setup]]
+- [[guides/data-ingestion|Data Ingestion]]
+- [[guides/running-searches|Running Searches]]
+- [[api-reference/graphql-schema|GraphQL Schema]]
+- [[api-reference/ingest-rest-api|Ingest REST API]]
+- [[deployment/aws|AWS Deployment]]
+
+---
+
+## Stack
+
+| Concern | Technology |
+| --- | --- |
+| Service | Spring Boot 3.3, Java 21 |
+| Search | OpenSearch 2.x (BM25 + k-NN) |
+| Embeddings | Ollama + nomic-embed-text (768-dim) |
+| Intent extraction | Ollama + mistral:7b |
+| API | GraphQL (Spring for GraphQL) |
+| Ingest | REST (Spring MVC) |
+| Infrastructure | Docker Compose |


### PR DESCRIPTION
## Summary

- Creates `docs/.obsidian/app.json` and `core-plugins.json` (Mermaid enabled, dark theme, live preview, graph/backlinks/tag-pane plugins on)
- Creates `docs/index.md` vault home page linking all sections with stack table
- Creates section `_index.md` placeholders for `architecture/`, `concepts/`, `guides/`, `api-reference/`, `deployment/`
- Creates placeholder doc files for all future pages, each with a 🚧 callout indicating which phase fills them in

## Test plan

- [ ] Open `docs/` in Obsidian — no errors, all folders visible in file explorer
- [ ] `docs/index.md` renders with working wiki-links to section indexes
- [ ] Mermaid renders correctly in Obsidian (enabled via `app.json`)
- [ ] `npx markdownlint-cli2 "**/*.md"` reports 0 errors

Closes #2